### PR TITLE
Upgraded to 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.0-1.19.2'
+version = '1.0-1.20.1'
 group = 'at.goldenretriveryt.fixmb' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'fixmb'
 
@@ -31,7 +31,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.19.2'
+    mappings channel: 'official', version: '1.20.1'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -117,7 +117,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19.2-43.2.0'
+    minecraft 'net.minecraftforge:forge:1.20.1-47.3.11'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -11,7 +11,7 @@ loaderVersion="[43,)" #mandatory This is typically bumped every Minecraft versio
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="All rights reserved"
 # A URL to refer people to when problems occur with this mod
-#issueTrackerURL="https://change.me.to.your.issue.tracker.example.invalid/" #optional
+issueTrackerURL="https://github.com/GoldenretriverYT/FixMouseButtonKeybinds/issues/" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
@@ -26,13 +26,13 @@ displayName="Fix Mouse Keybinds" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/
 #updateJSONURL="https://change.me.example.invalid/updates.json" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
-#displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
+displayURL="https://www.curseforge.com/minecraft/mc-mods/fix-mouse-keybinds/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
 # A text field displayed in the mod UI
 # The description text for the mod (multi line!) (#mandatory)
 description='''
-Fixes the fact that most mods do not directly listen to mouse button events, which causes mouse button keybinds to only work when pressing any key.'''
-
+Fixes the fact that most mods do not directly listen to mouse button events, which causes mouse button keybinds to only work when pressing any key.
+'''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
 [[dependencies.fixmb]] #optional
 # the modid of the dependency
@@ -51,6 +51,5 @@ side="BOTH"
 modId="minecraft"
 mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange="[1.19,1.20)"
+versionRange="[1.19,)"
 ordering="NONE"
-side="BOTH"


### PR DESCRIPTION
- Updated Minecraft version to 1.20.1
- Updated Forge to 1.20.1-47.3.11
- Added Display URL and pointed to [CurseForge page](https://www.curseforge.com/minecraft/mc-mods/fix-mouse-keybinds)
- Added Issues URL and pointed it to [this repo's Issues tab](https://github.com/GoldenretriverYT/FixMouseButtonKeybinds/issues)
- Removed requirement for the mod to be installed on the server
- Removed maximum Minecraft version

Tested with the [All the Mods 9 - ATM9](https://www.curseforge.com/minecraft/modpacks/all-the-mods-9) modpack (v0.3.5, MC v1.20.1, Forge v47.3.11), and didn't notice any issues.